### PR TITLE
build: export socketcan as a module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,6 +24,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+
+        _ = b.addModule("socketcan", .{ .root_source_file = b.path("src/socketcan.zig") });
+
+
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).


### PR DESCRIPTION
WHAT THIS DOES:

  * exports socket can as a module so it can be used by other projects